### PR TITLE
Upgrade versions to 6.8.8 and 7.6.2

### DIFF
--- a/6.8/Dockerfile
+++ b/6.8/Dockerfile
@@ -4,12 +4,12 @@ LABEL maintainer "https://github.com/blacktop"
 
 RUN apk add --no-cache openjdk8-jre su-exec
 
-ENV VERSION 6.8.7
+ENV VERSION 6.8.8
 ENV DOWNLOAD_URL "https://artifacts.elastic.co/downloads/elasticsearch"
 ENV ES_TARBAL "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}.tar.gz"
 ENV ES_TARBALL_ASC "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}.tar.gz.asc"
 ENV EXPECTED_SHA_URL "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}.tar.gz.sha512"
-ENV ES_TARBALL_SHA "ace12a099112ba16f8298d789dc0d4866349f54bdd66a9a6ba9bca08efb4387558d9962b2b2c28f3ed8ed1f02b1982dc13f7644f8805819137219c9a02fbaba1"
+ENV ES_TARBALL_SHA "7c5972d365a8a2a80c351039ff54a274bb1f95379d6f4feab4fa01360541bffa58409ffac6030acade24be54d1cc57e7ea24a7cf29531aba35a565718e30288d"
 ENV GPG_KEY "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 # https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.3.0.zip
 RUN apk add --no-cache bash

--- a/7.6/Dockerfile
+++ b/7.6/Dockerfile
@@ -4,12 +4,12 @@ LABEL maintainer "https://github.com/blacktop"
 
 RUN apk add --no-cache openjdk11-jre-headless su-exec
 
-ENV VERSION 7.6.1
+ENV VERSION 7.6.2
 ENV DOWNLOAD_URL "https://artifacts.elastic.co/downloads/elasticsearch"
 ENV ES_TARBAL "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-no-jdk-linux-x86_64.tar.gz"
 ENV ES_TARBALL_ASC "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-no-jdk-linux-x86_64.tar.gz.asc"
 ENV EXPECTED_SHA_URL "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}-no-jdk-linux-x86_64.tar.gz.sha512"
-ENV ES_TARBALL_SHA "da396be8bceec32b5f4c4f9091edee51710f39f5aa1135c7c392719d9fdd0c99e92b681cf628135013a37fd881dd15540d6c660a50bb18b47991f0d723aadb64"
+ENV ES_TARBALL_SHA "6197a0b62f577cd0692c1fb97a473a9971f8fef383dc6ef618035785dbc662947d2adbc425ce130ef531cbfaf9add9ed5da5a698387e770c49af820644d67e72"
 ENV GPG_KEY "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 
 RUN apk add --no-cache bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ blacktop/elasticsearch   7.3                 289MB
 blacktop/elasticsearch   7.2                 358MB
 blacktop/elasticsearch   7.1                 304MB
 blacktop/elasticsearch   7.0                 304MB
-blacktop/elasticsearch   6.8                 192MB
+blacktop/elasticsearch   6.8                 198MB
 blacktop/elasticsearch   6.7                 192MB
 blacktop/elasticsearch   6.6                 128MB
 blacktop/elasticsearch   6.5                 127MB

--- a/x-pack/Dockerfile
+++ b/x-pack/Dockerfile
@@ -18,8 +18,8 @@ RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends apt-transport-https && rm -rf /var/lib/apt/lists/* \
 	&& echo 'deb https://artifacts.elastic.co/packages/7.x/apt stable main' > /etc/apt/sources.list.d/elasticsearch.list
 
-ENV ELASTICSEARCH_VERSION 7.6.1
-ENV ELASTICSEARCH_DEB_VERSION 7.6.1
+ENV ELASTICSEARCH_VERSION 7.6.2
+ENV ELASTICSEARCH_DEB_VERSION 7.6.2
 ENV ELASTIC_CONTAINER=true
 
 RUN set -x \


### PR DESCRIPTION
`make all` => `"testcluster"`, with both `./LATEST` set to `7.6` and `6.8` locally (two runs).