### PR TITLE
Upgrade for ElasticSearch 6.8 to Alpine 3.14

### DIFF
--- a/6.8/Dockerfile
+++ b/6.8/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.9
+FROM alpine:3.14
 
 LABEL maintainer "https://github.com/blacktop"
 
-RUN apk add --no-cache openjdk8-jre su-exec
+RUN apk add --no-cache openjdk11-jre-headless bash su-exec
 
 ENV VERSION 6.8.13
 ENV DOWNLOAD_URL "https://artifacts.elastic.co/downloads/elasticsearch"
@@ -11,8 +11,9 @@ ENV ES_TARBALL_ASC "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}.tar.gz.asc"
 ENV EXPECTED_SHA_URL "${DOWNLOAD_URL}/elasticsearch-oss-${VERSION}.tar.gz.sha512"
 ENV ES_TARBALL_SHA "e06b3486585e67f1e34e4268834b6625de6c4dcc380b15551306f42b02b5b2a0997fa2c26e82d965e6040cbf2367f399d4802e881fc649972382c895fa925573"
 ENV GPG_KEY "46095ACC8548582C1A2699A9D27D666CD88E42B4"
-# https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.3.0.zip
-RUN apk add --no-cache bash
+ENV JAVA_HOME=/usr/lib/jvm/default-jvm \
+  PATH=/usr/lib/jvm/default-jvm/bin:$PATH
+#  https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-oss-6.3.0.zip
 RUN apk add --no-cache -t .build-deps wget ca-certificates gnupg openssl \
   && set -ex \
   && cd /tmp \

--- a/6.8/config/elastic/jvm.options
+++ b/6.8/config/elastic/jvm.options
@@ -1,0 +1,129 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+-Xms1g
+-Xmx1g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+# 8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
+
+## G1GC Configuration
+# NOTE: G1 GC is only supported on JDK version 10 or later
+# to use G1GC, uncomment the next two lines and update the version on the
+# following three lines to your version of the JDK
+# 10-13:-XX:-UseConcMarkSweepGC
+# 10-13:-XX:-UseCMSInitiatingOccupancyOnly
+14-:-XX:+UseG1GC
+14-:-XX:G1ReservePercent=25
+14-:-XX:InitiatingHeapOccupancyPercent=30
+
+## DNS cache policy
+# cache ttl in seconds for positive DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.ttl; set to -1 to cache forever
+-Des.networkaddress.cache.ttl=60
+# cache ttl in seconds for negative DNS lookups noting that this overrides the
+# JDK security property networkaddress.cache.negative ttl; set to -1 to cache
+# forever
+-Des.networkaddress.cache.negative.ttl=10
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# enable helpful NullPointerExceptions (https://openjdk.java.net/jeps/358), if
+# they are supported
+14-:-XX:+ShowCodeDetailsInExceptionMessages
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+#10-:-XX:UseAVX=2
+10-:-XX:UseAVX=1

--- a/6.8/config/elastic/log4j2.properties
+++ b/6.8/config/elastic/log4j2.properties
@@ -3,7 +3,7 @@ status = error
 appender.console.type = Console
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] [%node_name]%marker %m%n
 
 rootLogger.level = info
 rootLogger.appenderRef.console.ref = console


### PR DESCRIPTION
As discussed in the issue #25 the `JAVA_HOME` environment variable is not set.
Also there were several warnings in the _ElasticSearch_ startup according to `config/jvm.options` that need to be adjusted for _Java11_
```
$ docker run -p 9200:9200 -it elasticsearch-alpine-6.8
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
OpenJDK 64-Bit Server VM warning: UseAVX=2 is not supported on this CPU, setting it to UseAVX=1
[2021-11-14T20:17:42,794][INFO ][o.e.e.NodeEnvironment    ] [A_fhotN] using [1] data paths, mounts [[/usr/share/elasticsearch/data (<host_root_partition>)]], net usable_space [158.6gb], net total_space [182.2gb], types [ext4]
[2021-11-14T20:17:42,797][INFO ][o.e.e.NodeEnvironment    ] [A_fhotN] heap size [990.7mb], compressed ordinary object pointers [true]
[2021-11-14T20:17:42,799][INFO ][o.e.n.Node               ] [A_fhotN] node name derived from node ID [A_fhotN3S3Wkxk8Fiin05A]; set [node.name] to override
[2021-11-14T20:17:42,800][INFO ][o.e.n.Node               ] [A_fhotN] version[6.8.13], pid[1], build[oss/tar/be13c69/2020-10-16T09:09:46.555371Z], OS[Linux/5.10.0-9-amd64/amd64], JVM[Alpine/OpenJDK 64-Bit Server VM/11.0.11/11.0.11+9-alpine-r0]
[2021-11-14T20:17:42,800][INFO ][o.e.n.Node               ] [A_fhotN] JVM arguments [-Xms1g, -Xmx1g, -XX:+UseConcMarkSweepGC, -XX:CMSInitiatingOccupancyFraction=75, -XX:+UseCMSInitiatingOccupancyOnly, -Des.networkaddress.cache.ttl=60, -Des.networkaddress.cache.negative.ttl=10, -XX:+AlwaysPreTouch, -Xss1m, -Djava.awt.headless=true, -Dfile.encoding=UTF-8, -Djna.nosys=true, -XX:-OmitStackTraceInFastThrow, -Dio.netty.noUnsafe=true, -Dio.netty.noKeySetOptimization=true, -Dio.netty.recycler.maxCapacityPerThread=0, -Dlog4j.shutdownHookEnabled=false, -Dlog4j2.disable.jmx=true, -Djava.io.tmpdir=/usr/share/elasticsearch/tmp, -XX:+HeapDumpOnOutOfMemoryError, -XX:HeapDumpPath=data, -XX:ErrorFile=logs/hs_err_pid%p.log, -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m, -Djava.locale.providers=COMPAT, -XX:UseAVX=2, -Des.cgroups.hierarchy.override=/, -Des.path.home=/usr/share/elasticsearch, -Des.path.conf=/usr/share/elasticsearch/config, -Des.distribution.flavor=oss, -Des.distribution.type=tar]
[2021-11-14T20:17:43,999][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [aggs-matrix-stats]
[2021-11-14T20:17:43,999][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [analysis-common]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [ingest-common]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [ingest-geoip]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [ingest-user-agent]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [lang-expression]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [lang-mustache]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [lang-painless]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [mapper-extras]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [parent-join]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [percolator]
[2021-11-14T20:17:44,000][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [rank-eval]
[2021-11-14T20:17:44,001][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [reindex]
[2021-11-14T20:17:44,001][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [repository-url]
[2021-11-14T20:17:44,001][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [transport-netty4]
[2021-11-14T20:17:44,001][INFO ][o.e.p.PluginsService     ] [A_fhotN] loaded module [tribe]
[2021-11-14T20:17:44,002][INFO ][o.e.p.PluginsService     ] [A_fhotN] no plugins loaded
[2021-11-14T20:17:48,217][INFO ][o.e.d.DiscoveryModule    ] [A_fhotN] using discovery type [zen] and host providers [settings]
[2021-11-14T20:17:48,938][INFO ][o.e.n.Node               ] [A_fhotN] initialized
[2021-11-14T20:17:48,939][INFO ][o.e.n.Node               ] [A_fhotN] starting ...
[2021-11-14T20:17:49,180][INFO ][o.e.t.TransportService   ] [A_fhotN] publish_address {172.17.0.2:9300}, bound_addresses {0.0.0.0:9300}
[2021-11-14T20:17:49,200][INFO ][o.e.b.BootstrapChecks    ] [A_fhotN] bound or publishing to a non-loopback address, enforcing bootstrap checks
[2021-11-14T20:17:52,267][INFO ][o.e.c.s.MasterService    ] [A_fhotN] zen-disco-elected-as-master ([0] nodes joined), reason: new_master {A_fhotN}{A_fhotN3S3Wkxk8Fiin05A}{q2fRIxcATfmHyVBMzal7Jg}{172.17.0.2}{172.17.0.2:9300}
[2021-11-14T20:17:52,273][INFO ][o.e.c.s.ClusterApplierService] [A_fhotN] new_master {A_fhotN}{A_fhotN3S3Wkxk8Fiin05A}{q2fRIxcATfmHyVBMzal7Jg}{172.17.0.2}{172.17.0.2:9300}, reason: apply cluster state (from master [master {A_fhotN}{A_fhotN3S3Wkxk8Fiin05A}{q2fRIxcATfmHyVBMzal7Jg}{172.17.0.2}{172.17.0.2:9300} committed version [1] source [zen-disco-elected-as-master ([0] nodes joined)]])
[2021-11-14T20:17:52,288][INFO ][o.e.h.n.Netty4HttpServerTransport] [A_fhotN] publish_address {172.17.0.2:9200}, bound_addresses {0.0.0.0:9200}
[2021-11-14T20:17:52,289][INFO ][o.e.n.Node               ] [A_fhotN] started
[2021-11-14T20:17:52,358][INFO ][o.e.g.GatewayService     ] [A_fhotN] recovered [0] indices into cluster_state
^C[2021-11-14T20:20:08,020][INFO ][o.e.n.Node               ] [A_fhotN] stopping ...
[2021-11-14T20:20:08,039][INFO ][o.e.n.Node               ] [A_fhotN] stopped
[2021-11-14T20:20:08,039][INFO ][o.e.n.Node               ] [A_fhotN] closing ...
[2021-11-14T20:20:08,052][INFO ][o.e.n.Node               ] [A_fhotN] closed
```