### PR TITLE
Disable UseAVX Parameter

### DIFF
--- a/6.8/config/elastic/jvm.options
+++ b/6.8/config/elastic/jvm.options
@@ -126,4 +126,3 @@
 
 # temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
 #10-:-XX:UseAVX=2
-10-:-XX:UseAVX=1


### PR DESCRIPTION
As documented in the related issue:
[AVX Instructions not supported](https://github.com/blacktop/docker-elasticsearch-alpine/issues/44)
the `UseAVX` Parameter is tightly dependent on the Docker Host and can only be enabled according to the Docker Host system support.

Still the _JVM_ will enable it for systems where it is supported.

So, this option must be excluded from the Docker Image to make it compatible for systems with and without _AVX_ support.