### PR TITLE
Improvements to CI action, and upgrade Alpine Versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,11 +18,6 @@ jobs:
       matrix:
         versions: [
           {
-            name: "v2",
-            context: "2.4",
-            versions: "2 2.4 2.4.6"
-          },
-          {
             name: "v5",
             context: "5.6",
             versions: "5 5.6 5.6.16"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,14 +18,14 @@ jobs:
       matrix:
         versions: [
           {
-            name: "v1",
-            context: "1.7",
-            versions: "1 1.7 1.7.6"
-          },
-          {
             name: "v2",
             context: "2.4",
             versions: "2 2.4 2.4.6"
+          },
+          {
+            name: "v5",
+            context: "5.6",
+            versions: "5 5.6 5.6.16"
           },
           {
             name: "v6",

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,23 +19,28 @@ jobs:
         versions: [
           {
             name: "v1",
+            context: "1.7",
             versions: "1 1.7 1.7.6"
           },
           {
             name: "v2",
+            context: "2.4",
             versions: "2 2.4 2.4.5"
           },
           {
             name: "v6",
-            versions: "1 1.7 1.7.6"
+            context: "6.8",
+            versions: "6 6.8 6.8.23"
           },
           {
             name: "v7",
-            versions: "1 1.7 1.7.6"
+            context: "7.17",
+            versions: "7 7.17 7.17.2"
           },
           {
             name: "v8",
-            versions: "1 1.7 1.7.6"
+            context: "8.1",
+            versions: "8 8.1 8.1.2"
           }
         ]
     permissions:
@@ -53,14 +58,19 @@ jobs:
           VERSION_LIST: ${{ matrix.versions.versions }}
         run: |
           IMAGE_LIST=""
+          IMAGE_METADATA_LIST="ghcr.io/$REPOSITORY_OWNER/elasticsearch"
+          LOGIN_DOCKER_HUB=0
 
           if [ "$REPOSITORY_OWNER" = "blacktop" ] ; then
+            LOGIN_DOCKER_HUB=1
+            IMAGE_METADATA_LIST="$IMAGE_METADATA_LIST\nblacktop/elasticsearch"
             for version in $VERSION_LIST; do
               IMAGE_LIST="$IMAGE_LIST\nblacktop/elasticsearch:$version"
             done
           fi
 
           for version in $VERSION_LIST; do
+            
             IMAGE_LIST="$IMAGE_LIST\nghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
           done
 
@@ -68,10 +78,46 @@ jobs:
           IMAGE_LIST="${IMAGE_LIST//$'\n'/'%0A'}"
           IMAGE_LIST="${IMAGE_LIST//$'\r'/'%0D'}"
 
-          echo "::set-output name=imageList::$IMAGE_LIST"
+          IMAGE_METADATA_LIST="${IMAGE_METADATA_LIST//'%'/'%25'}"
+          IMAGE_METADATA_LIST="${IMAGE_METADATA_LIST//$'\n'/'%0A'}"
+          IMAGE_METADATA_LIST="${IMAGE_METADATA_LIST//$'\r'/'%0D'}"
 
-      - name: Debug imagelist
-        env:
-          IMAGE_LIST: ${{ steps.imageListGenerator.outputs.imageList }}
-        run: |
-          echo -e "$IMAGE_LIST"
+          echo "::set-output name=imageList::$IMAGE_LIST"
+          echo "::set-output name=imageMetadataList::$IMAGE_METADATA_LIST"
+          echo "::set-output name=loginDockerHub::$LOGIN_DOCKER_HUB"
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ steps.imageListGenerator.outputs.imageMetadataList }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        if: ${{ steps.imageListGenerator.outputs.loginDockerHub == '1' }}
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        timeout-minutes: 20
+        with:
+          context: ./${{ matrix.versions.context }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.imageListGenerator.outputs.imageList }}
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -45,7 +45,8 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Create images list for $ {{ matrix.versions.name }}
+      - name: Create images list for ${{ matrix.versions.name }}
+        shell: bash
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           VERSION_LIST: ${{ matrix.versions.versions }}
@@ -62,4 +63,10 @@ jobs:
             IMAGE_LIST="$IMAGE_LIST\nghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
           done
 
-          echo $IMAGE_LIST
+          echo -e $IMAGE_LIST
+
+          IMAGE_LIST="${IMAGE_LIST//'%'/'%25'}"
+          IMAGE_LIST="${IMAGE_LIST//$'\n'/'%0A'}"
+          IMAGE_LIST="${IMAGE_LIST//$'\r'/'%0D'}"
+
+          echo -e "::set-output name=imageList::$IMAGE_LIST"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -65,18 +65,21 @@ jobs:
             LOGIN_DOCKER_HUB=1
             IMAGE_METADATA_LIST="$IMAGE_METADATA_LIST\nblacktop/elasticsearch"
             for version in $VERSION_LIST; do
-              IMAGE_LIST="$IMAGE_LIST\nblacktop/elasticsearch:$version"
+              if [ -z "$IMAGE_LIST" ]; then
+                IMAGE_LIST="blacktop/elasticsearch:$version"
+              else
+                IMAGE_LIST="$IMAGE_LIST,blacktop/elasticsearch:$version"
+              fi
             done
           fi
 
           for version in $VERSION_LIST; do
-            
-            IMAGE_LIST="$IMAGE_LIST\nghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
+            if [ -z "$IMAGE_LIST" ]; then
+              IMAGE_LIST="ghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
+            else
+              IMAGE_LIST="$IMAGE_LIST,ghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
+            fi
           done
-
-          IMAGE_LIST="${IMAGE_LIST//'%'/'%25'}"
-          IMAGE_LIST="${IMAGE_LIST//$'\n'/'%0A'}"
-          IMAGE_LIST="${IMAGE_LIST//$'\r'/'%0D'}"
 
           IMAGE_METADATA_LIST="${IMAGE_METADATA_LIST//'%'/'%25'}"
           IMAGE_METADATA_LIST="${IMAGE_METADATA_LIST//$'\n'/'%0A'}"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,131 +8,58 @@ name: Publish Docker Image
 on:
   push:
     branches:
-      - '**'
+      - 'master'
 
 jobs:
   push_to_registries:
     name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        versions: [
+          {
+            name: "v1",
+            versions: "1 1.7 1.7.6"
+          },
+          {
+            name: "v2",
+            versions: "1 1.7 1.7.6"
+          },
+          {
+            name: "v6",
+            versions: "1 1.7 1.7.6"
+          },
+          {
+            name: "v7",
+            versions: "1 1.7 1.7.6"
+          },
+          {
+            name: "v8",
+            versions: "1 1.7 1.7.6"
+          }
+        ]
     permissions:
       packages: write
       contents: read
     steps:
-      -
-        name: Check out the repo
+      - name: Check out the repo
         uses: actions/checkout@v3
 
-      -
-        name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            blacktop/elasticsearch
-            ghcr.io/${{ github.repository }}
+      - name: Create images list for $ {{ matrix.versions.name }}
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          VERSION_LIST: ${{ matrix.versions.versions }}
+        run: |
+          IMAGE_LIST=""
 
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+          if [ "$REPOSITORY_OWNER" = "blacktop" ] ; then
+            for version in $VERSION_LIST; do
+              IMAGE_LIST="$IMAGE_LIST\nblacktop/elasticsearch:$version"
+            done
+          fi
 
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+          for version in $VERSION_LIST; do
+            IMAGE_LIST="$IMAGE_LIST\ghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
+          done
 
-      -
-        name: Docker Login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      -
-        name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image (v1)
-        id: docker_build_1
-        uses: docker/build-push-action@v3
-        timeout-minutes: 20
-        with:
-          context: ./1.7
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            blacktop/elasticsearch:1
-            blacktop/elasticsearch:1.7
-            blacktop/elasticsearch:1.7.6
-            ghcr.io/blacktop/elasticsearch:1
-            ghcr.io/blacktop/elasticsearch:1.7
-            ghcr.io/blacktop/elasticsearch:1.7.6
-          platforms: linux/amd64,linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push Docker image (v6)
-        id: docker_build_6
-        uses: docker/build-push-action@v3
-        timeout-minutes: 20
-        with:
-          context: ./6.8
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            blacktop/elasticsearch:6
-            blacktop/elasticsearch:6.8
-            blacktop/elasticsearch:6.8.23
-            ghcr.io/blacktop/elasticsearch:6
-            ghcr.io/blacktop/elasticsearch:6.8
-            ghcr.io/blacktop/elasticsearch:6.8.23
-          platforms: linux/amd64,linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push Docker image (v7)
-        id: docker_build_7
-        uses: docker/build-push-action@v3
-        timeout-minutes: 20
-        with:
-          context: ./7.17
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            blacktop/elasticsearch:7
-            blacktop/elasticsearch:7.17
-            blacktop/elasticsearch:7.17.2
-            ghcr.io/blacktop/elasticsearch:7
-            ghcr.io/blacktop/elasticsearch:7.17
-            ghcr.io/blacktop/elasticsearch:7.17.2
-          platforms: linux/amd64,linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push Docker image (v8)
-        id: docker_build_8
-        uses: docker/build-push-action@v3
-        timeout-minutes: 20
-        with:
-          context: ./8.1
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            blacktop/elasticsearch:latest
-            blacktop/elasticsearch:8
-            blacktop/elasticsearch:8.1
-            blacktop/elasticsearch:8.1.2
-            ghcr.io/blacktop/elasticsearch:latest
-            ghcr.io/blacktop/elasticsearch:8
-            ghcr.io/blacktop/elasticsearch:8.1
-            ghcr.io/blacktop/elasticsearch:8.1.2
-          platforms: linux/amd64,linux/arm64
-          labels: ${{ steps.meta.outputs.labels }}
-
-      # - name: Build and push Docker image (X-Pack)
-      #   id: docker_build_x_pack
-      #   uses: docker/build-push-action@v3
-      #   with:
-      #     context: ./x-pack
-      #     push: ${{ github.event_name != 'pull_request' }}
-      #     tags: |
-      #       blacktop/elasticsearch:x-pack
-      #       blacktop/elasticsearch:x-pack-7
-      #       blacktop/elasticsearch:x-pack-7.15
-      #       blacktop/elasticsearch:x-pack-7.15.1
-      #     labels: ${{ steps.meta.outputs.labels }}
+          echo $IMAGE_LIST

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
           for version in $VERSION_LIST; do
-            IMAGE_LIST="$IMAGE_LIST\ghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
+            IMAGE_LIST="$IMAGE_LIST\nghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
           done
 
           echo $IMAGE_LIST

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Create images list for ${{ matrix.versions.name }}
         shell: bash
+        id: imageListGenerator
         env:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           VERSION_LIST: ${{ matrix.versions.versions }}
@@ -63,10 +64,14 @@ jobs:
             IMAGE_LIST="$IMAGE_LIST\nghcr.io/$REPOSITORY_OWNER/elasticsearch:$version"
           done
 
-          echo -e $IMAGE_LIST
-
           IMAGE_LIST="${IMAGE_LIST//'%'/'%25'}"
           IMAGE_LIST="${IMAGE_LIST//$'\n'/'%0A'}"
           IMAGE_LIST="${IMAGE_LIST//$'\r'/'%0D'}"
 
-          echo -e "::set-output name=imageList::$IMAGE_LIST"
+          echo "::set-output name=imageList::$IMAGE_LIST"
+
+      - name: Debug imagelist
+        env:
+          IMAGE_LIST: ${{ steps.imageListGenerator.outputs.imageList }}
+        run: |
+          echo -e "$IMAGE_LIST"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -23,7 +23,7 @@ jobs:
           },
           {
             name: "v2",
-            versions: "1 1.7 1.7.6"
+            versions: "2 2.4 2.4.5"
           },
           {
             name: "v6",

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
           {
             name: "v2",
             context: "2.4",
-            versions: "2 2.4 2.4.5"
+            versions: "2 2.4 2.4.6"
           },
           {
             name: "v6",

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,20 +1,19 @@
-FROM alpine:3.5
+FROM alpine:3.14
 
 LABEL maintainer "https://github.com/blacktop"
 
-RUN apk add --no-cache openjdk8-jre tini su-exec
-
-ENV ES_VERSION 2.4.4
+ENV ES_VERSION 2.4.5
 
 ENV DOWNLOAD_URL "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution"
 ENV ES_TARBAL "${DOWNLOAD_URL}/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz"
 ENV ES_TARBALL_ASC "${DOWNLOAD_URL}/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz.asc"
 ENV SHA1_URL "${DOWNLOAD_URL}/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz.sha1"
-ENV ES_TARBALL_SHA1 "cdb5068d1baa07388e522c3bc04cca38aa8f3048"
+ENV ES_TARBALL_SHA1 "180353a1a65995f5e4533ff0a58f18e1e85f28ae"
 ENV GPG_KEY "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 
-RUN apk add --no-cache bash
-RUN apk add --no-cache -t .build-deps wget ca-certificates gnupg openssl \
+RUN apk add --no-cache openjdk8-jre tini su-exec java-jna-native \
+  && apk add --no-cache bash \
+  && apk add --no-cache -t .build-deps wget ca-certificates gnupg openssl \
   && cd /tmp \
   && echo "===> Install Elasticsearch..." \
   && EXPECTED_SHA=$(wget -O - ${SHA1_URL}) \

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -2,13 +2,13 @@ FROM alpine:3.14
 
 LABEL maintainer "https://github.com/blacktop"
 
-ENV ES_VERSION 2.4.5
+ENV ES_VERSION 2.4.6
 
 ENV DOWNLOAD_URL "https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution"
 ENV ES_TARBAL "${DOWNLOAD_URL}/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz"
 ENV ES_TARBALL_ASC "${DOWNLOAD_URL}/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz.asc"
 ENV SHA1_URL "${DOWNLOAD_URL}/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz.sha1"
-ENV ES_TARBALL_SHA1 "180353a1a65995f5e4533ff0a58f18e1e85f28ae"
+ENV ES_TARBALL_SHA1 "c3441bef89cd91206edf3cf3bd5c4b62550e60a9"
 ENV GPG_KEY "46095ACC8548582C1A2699A9D27D666CD88E42B4"
 
 RUN apk add --no-cache openjdk8-jre tini su-exec java-jna-native \

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -1,13 +1,12 @@
-FROM gliderlabs/alpine:3.4
+FROM gliderlabs/alpine:3.14
 
 MAINTAINER blacktop, https://github.com/blacktop
 
-RUN apk-install openjdk8-jre tini su-exec
-
 ENV ELASTIC 5.0.2
 
-RUN apk-install bash
-RUN apk-install -t build-deps wget ca-certificates \
+RUN apk-install openjdk8-jre tini su-exec java-jna-native \
+  && apk-install bash \
+  && apk-install -t build-deps wget ca-certificates \
   && cd /tmp \
   && wget -O elasticsearch-$ELASTIC.tar.gz https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELASTIC.tar.gz \
   && tar -xzf elasticsearch-$ELASTIC.tar.gz \


### PR DESCRIPTION
This PR modified the Github action so it uses a matrix, and is generic so that any forked repo can build its own repo images.

It also updates the Version 2, and 5 images to use Alpine 3.14